### PR TITLE
[Bug] Change Guild Permissions Update to Replace INTO

### DIFF
--- a/zone/guild_mgr.cpp
+++ b/zone/guild_mgr.cpp
@@ -1581,15 +1581,15 @@ bool GuildBankManager::AllowedToWithdraw(uint32 GuildID, uint16 Area, uint16 Slo
 
 void ZoneGuildManager::UpdateRankPermission(uint32 gid, uint32 charid, uint32 fid, uint32 rank, uint32 value) {
 	auto res = m_guilds.find(gid);
-	
+
 	if (value) {
 		res->second->functions[fid] |= (1UL << (8 - rank));
 	} else {
 		res->second->functions[fid] &= ~(1UL << (8 - rank));
 	}
 
-	auto query = fmt::format("REPLACE INTO guild_permissions (perm_id, guild_id, permission) "
-			"VALUES('{}','{}','{}');",
+	auto query = fmt::format("INSERT INTO guild_permissions (perm_id, guild_id, permission) "
+			"VALUES('{}','{}','{}') ON DUPLICATE KEY UPDATE guild_permissions.permission = VALUES(permission);",
 			fid,
 			gid,
 			res->second->functions[fid]

--- a/zone/guild_mgr.cpp
+++ b/zone/guild_mgr.cpp
@@ -1580,17 +1580,21 @@ bool GuildBankManager::AllowedToWithdraw(uint32 GuildID, uint16 Area, uint16 Slo
 }
 
 void ZoneGuildManager::UpdateRankPermission(uint32 gid, uint32 charid, uint32 fid, uint32 rank, uint32 value) {
-
 	auto res = m_guilds.find(gid);
+	
 	if (value) {
 		res->second->functions[fid] |= (1UL << (8 - rank));
-	}
-	else {
+	} else {
 		res->second->functions[fid] &= ~(1UL << (8 - rank));
 	}
-	auto query = fmt::format("UPDATE guild_permissions SET permission = {} WHERE perm_id = {} AND guild_id = {};", res->second->functions[fid], fid, gid);
-	auto results = m_db->QueryDatabase(query);
 
+	auto query = fmt::format("REPLACE INTO guild_permissions (perm_id, guild_id, permission) "
+			"VALUES('{}','{}','{}');",
+			fid,
+			gid,
+			res->second->functions[fid]
+	);
+	auto results = m_db->QueryDatabase(query);
 }
 
 void ZoneGuildManager::SendPermissionUpdate(uint32 guild_id, uint32 rank, uint32 function_id, uint32 value)


### PR DESCRIPTION
Since the guild permissions are not auto populated with defaults (Should they be?), the update query is failing on a clean entry due to the where condition inherit with the update clause.

Swapped over to a replace into format.

Schema Changed to:

```sql
CREATE TABLE `guild_permissions` (
	`id` INT(11) NOT NULL AUTO_INCREMENT,
	`perm_id` INT(11) NOT NULL DEFAULT '0',
	`guild_id` INT(11) NOT NULL DEFAULT '0',
	`permission` INT(11) NOT NULL DEFAULT '0',
	PRIMARY KEY (`id`) USING BTREE,
	UNIQUE INDEX `perm_id_guild_id` (`perm_id`, `guild_id`) USING BTREE
)
COLLATE='latin1_swedish_ci'
ENGINE=InnoDB
;

```

A unique key was created for `perm_id` and `guild_id` as these should be unique combinations.